### PR TITLE
Adjust annotation output based on severity level

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,14 @@
 import { startGroup, endGroup } from '@actions/core';
 import { issueCommand } from '@actions/core/lib/command';
-import { ESLint } from 'eslint';
+import { ESLint, Linter } from 'eslint';
+
+// https://eslint.org/docs/4.0.0/user-guide/configuring#configuring-rules
+// https://github.com/actions/toolkit/blob/main/docs/commands.md#log-level
+const severityLabels: { [key in Linter.Severity]: string } = {
+  0: 'debug',
+  1: 'warning',
+  2: 'error',
+};
 
 const GitHubActionsReporter: ESLint.Formatter = {
   format: (results) => {
@@ -9,6 +17,7 @@ const GitHubActionsReporter: ESLint.Formatter = {
     const errors = results.flatMap((result) =>
       result.messages.map((message) => ({
         message: message.message,
+        severity: severityLabels[message.severity],
         properties: {
           file: result.filePath,
           line: message.line.toString(),
@@ -17,8 +26,8 @@ const GitHubActionsReporter: ESLint.Formatter = {
       }))
     );
 
-    for (const { message, properties } of errors) {
-      issueCommand('error', properties, message);
+    for (const { severity, properties, message } of errors) {
+      issueCommand(severity, properties, message);
     }
 
     endGroup();


### PR DESCRIPTION
Hi @jamesacarr.

Thanks for making this package!
We, at [FirmNav](https://github.com/firmnav), are transitioning away from our own internal eslint formatter, and thought yours looks like a good replacement!
While transitioning we however noticed warnings were being reported as errors.
This PR is an attempt to rectify that. If anything should be changed, please don't hesitate to say so.

